### PR TITLE
Clean up nested promises and refactor error handling

### DIFF
--- a/src/main/frontend/src/components/Schemata.vue
+++ b/src/main/frontend/src/components/Schemata.vue
@@ -1,5 +1,5 @@
 <template xmlns:v-slot="http://www.w3.org/1999/XSL/Transform">
-    <v-card class="xs12"  min-height="45vh">
+    <v-card class="xs12" min-height="45vh">
         <v-card-title>
             <v-text-field
                     v-model="search"
@@ -11,6 +11,7 @@
         </v-card-title>
         <v-card-text>
             <v-treeview
+                    dense
                     :items="items"
                     :search="search"
                     :filter="filter"
@@ -28,6 +29,13 @@
 </template>
 
 <script>
+    function ensureHttpOk(response) {
+        if (!response.ok) {
+            throw Error(`HTTP ${response.status}: ${response.statusText} (${response.url})`);
+        }
+        return response;
+    }
+
     export default {
         data: () => ({
             items: [],
@@ -39,8 +47,12 @@
                 return (item, search, textKey) => item[textKey].indexOf(search) > -1
             },
             selected: {
-                get() { return [this.$store.state.selected]},
-                set(value) { this.$store.commit('select', value[0])}
+                get() {
+                    return [this.$store.state.selected]
+                },
+                set(value) {
+                    this.$store.commit('select', value[0])
+                }
             }
         },
         created() {
@@ -50,115 +62,83 @@
             loadOrganizations() {
                 let vm = this
                 fetch('/organizations')
-                    .then(
-                        function (response) {
-                            if (response.status !== 200) {
-                                vm.$emit('vs-error', {status: response.status, message: response.text()})
-                            }
-                            response.json().then(function (data) {
-                                for (let organization of data) {
-                                    organization.id = organization.organizationId
-                                    organization.type = 'organization'
-                                    organization.children = []
-                                    vm.items.push(organization)
-                                }
-                            });
+                    .then(ensureHttpOk)
+                    .then(response => response.json())
+                    .then(data => {
+                        for (let organization of data) {
+                            organization.id = organization.organizationId
+                            organization.type = 'organization'
+                            organization.children = []
+                            vm.items.push(organization)
                         }
-                    )
-                    .catch(function (err) {
-                        vm.$emit('vs-error', {status: 0, message: err})
-                    });
+                    })
             },
 
             async loadChildren(item) {
+                let vm = this
+                let loadPromise = undefined
                 switch (item.type) {
                     case 'organization':
-                        return this.loadUnits(item)
+                        loadPromise = this.loadUnits(item)
+                        break
                     case 'unit':
-                        return this.loadContexts(item)
+                        loadPromise = this.loadContexts(item)
+                        break
                     case 'context':
-                        return this.loadSchemata(item)
+                        loadPromise = this.loadSchemata(item)
+                        break
                     default:
-                        this.$emit('vs-error', {
-                            status: 0,
-                            message: `Unknown type ${item.type} requested. Current selections: ${item}.`
+                        loadPromise = new Promise(() => {
+                            throw Error(`Unknown type ${item.type} requested. Current selections: ${JSON.stringify(item)}.`)
                         })
                 }
+                loadPromise.catch(function (err) {
+                    vm.$emit('vs-error', {message: err})
+                });
+                return loadPromise
             },
 
             async loadUnits(org) {
-                let vm = this
                 return fetch(`/organizations/${org.id}/units`)
-                    .then(
-                        function (response) {
-                            if (response.status !== 200) {
-                                vm.$emit('vs-error', {status: response.status, message: response.text()})
-                                return;
-                            }
-                            response.json().then(function (data) {
-                                for (let unit of data) {
-                                    unit.id = `${org.id}-${unit.unitId}`
-                                    unit.type = 'unit'
-                                    unit.children = []
-                                    org.children.push(unit)
-                                }
-                            });
+                    .then(ensureHttpOk)
+                    .then(response => response.json())
+                    .then(data => {
+                        for (let unit of data) {
+                            unit.id = `${org.id}-${unit.unitId}`
+                            unit.type = 'unit'
+                            unit.children = []
+                            org.children.push(unit)
                         }
-                    )
-                    .catch(function (err) {
-                        // TODO factor out error handling
-                        vm.$emit('vs-error', {status: 0, message: err})
-                    });
+                    })
+
 
             },
             async loadContexts(unit) {
-                let vm = this
                 return fetch(`/organizations/${unit.organizationId}/units/${unit.unitId}/contexts`)
-                    .then(
-                        function (response) {
-                            if (response.status !== 200) {
-                                vm.$emit('vs-error', {status: response.status, message: response.text()})
-                                return;
-                            }
-                            response.json().then(function (data) {
-                                for (let context of data) {
-                                    context.id = `${unit.id}-${context.contextId}`
-                                    context.name = context.namespace
-                                    context.type = 'context'
-                                    context.children = []
-                                    unit.children.push(context)
-                                }
-                            });
+                    .then(ensureHttpOk)
+                    .then(response => response.json())
+                    .then(data => {
+                        for (let context of data) {
+                            context.id = `${unit.id}-${context.contextId}`
+                            context.name = context.namespace
+                            context.type = 'context'
+                            context.children = []
+                            unit.children.push(context)
                         }
-                    )
-                    .catch(function (err) {
-                        // TODO factor out error handling
-                        vm.$emit('vs-error', {status: 0, message: err})
-                    });
-            },
+                    })
+            }
+            ,
             async loadSchemata(context) {
-                let vm = this
                 return fetch(`/organizations/${context.organizationId}/units/${context.unitId}/contexts/${context.contextId}/schemas`)
-                    .then(
-                        function (response) {
-                            if (response.status !== 200) {
-                                vm.$emit('vs-error', {status: response.status, message: response.text()})
-                                return;
-                            }
-                            response.json().then(function (data) {
-                                for (let schema of data) {
-                                    schema.id = `${context.id}-${schema.schemaId}`
-                                    schema.type = 'schema'
-
-                                    context.children.push(schema)
-                                }
-                            });
+                    .then(ensureHttpOk)
+                    .then(response => response.json())
+                    .then(data => {
+                        for (let schema of data) {
+                            schema.id = `${context.id}-${schema.schemaId}`
+                            schema.type = 'schema'
+                            context.children.push(schema)
                         }
-                    )
-                    .catch(function (err) {
-                        // TODO factor out error handling
-                        vm.$emit('vs-error', {status: 0, message: err})
-                    });
+                    })
             }
         }
     }

--- a/src/main/frontend/src/views/Schemata.vue
+++ b/src/main/frontend/src/views/Schemata.vue
@@ -45,7 +45,7 @@
         },
         methods: {
             async onError(event) {
-                this.error = await event.message + ` (HTTP ${event.status})`
+                this.error = await event.message
             }
         }
     }


### PR DESCRIPTION
Closes #28.

Makes treeview nodes load and open on the first click.
Reason was a nested `Promise` that snuck in undetected.