### PR TITLE
Add creation dialogs for schema and schema version

### DIFF
--- a/src/main/frontend/src/App.vue
+++ b/src/main/frontend/src/App.vue
@@ -90,7 +90,7 @@
                     {route: '/unit', title: 'New Unit', icon: mdiStore},
                     {route: '/context', title: 'New Context', icon: mdiEllipseOutline},
                     {route: '/schema', title: 'New Schema', icon: mdiFileDocument},
-                    {route: '/404', title: 'New Schema Version', icon: mdiTag},
+                    {route: '/schemaVersion', title: 'New Schema Version', icon: mdiTag},
                 ],
                 icons: {
                     sync: mdiSync,

--- a/src/main/frontend/src/App.vue
+++ b/src/main/frontend/src/App.vue
@@ -89,7 +89,7 @@
                     {route: '/organization', title: 'New Organization', icon: mdiFactory},
                     {route: '/unit', title: 'New Unit', icon: mdiStore},
                     {route: '/context', title: 'New Context', icon: mdiEllipseOutline},
-                    {route: '/404', title: 'New Schema', icon: mdiFileDocument},
+                    {route: '/schema', title: 'New Schema', icon: mdiFileDocument},
                     {route: '/404', title: 'New Schema Version', icon: mdiTag},
                 ],
                 icons: {

--- a/src/main/frontend/src/api/SchemataRepository.js
+++ b/src/main/frontend/src/api/SchemataRepository.js
@@ -112,4 +112,20 @@ export default {
             .then(ensureCreated)
             .then(response => response.data)
     },
+    createSchemaVersion(
+        organization, unit, context, schema,
+        specification, description, status, previousVersion, currentVersion) {
+        return Repository.post(resources.versions(organization, unit, context, schema),
+            {
+                schemaVersionId: '',
+                specification: specification,
+                status: status,
+                previousVersion: previousVersion,
+                currentVersion: currentVersion,
+                description: description
+            }
+        )
+            .then(ensureCreated)
+            .then(response => response.data)
+    },
 }

--- a/src/main/frontend/src/api/SchemataRepository.js
+++ b/src/main/frontend/src/api/SchemataRepository.js
@@ -6,6 +6,7 @@ const resources = {
     units: (o) => `/organizations/${o}/units`,
     contexts: (o, u) => `/organizations/${o}/units/${u}/contexts`,
     categories: () => '/schema/categories',
+    scopes: () => '/schema/scopes',
     schemata: (o, u, c) => `/organizations/${o}/units/${u}/contexts/${c}/schemas`,
     versions: (o, u, c, s) => `/organizations/${o}/units/${u}/contexts/${c}/schemas/${s}/versions`
 }
@@ -48,7 +49,11 @@ export default {
             .then(ensureOk)
             .then(response => response.data)
     },
-
+    getScopes() {
+        return Repository.get(resources.scopes())
+            .then(ensureOk)
+            .then(response => response.data)
+    },
     getSchemata(organization, unit, context) {
         return Repository.get(resources.schemata(organization, unit, context))
             .then(ensureOk)
@@ -88,6 +93,19 @@ export default {
             {
                 contextId: '',
                 namespace: namespace,
+                description: description
+            }
+        )
+            .then(ensureCreated)
+            .then(response => response.data)
+    },
+    createSchema(organization, unit, context, name, scope, category, description) {
+        return Repository.post(resources.schemata(organization, unit, context),
+            {
+                contextId: '',
+                name: name,
+                scope: scope,
+                category: category,
                 description: description
             }
         )

--- a/src/main/frontend/src/components/Schema.vue
+++ b/src/main/frontend/src/components/Schema.vue
@@ -1,6 +1,6 @@
 <template>
     <v-card class="xs12" height="95vh" width="100%">
-        <v-card-title>Context</v-card-title>
+        <v-card-title>Schema</v-card-title>
         <v-card-text>
             <v-form
                     ref="form"
@@ -9,8 +9,8 @@
                 <v-row>
                     <v-col class="d-flex" cols="12">
                         <v-text-field
-                                v-model="contextId"
-                                label="ContextID"
+                                v-model="schemaId"
+                                label="SchemaID"
                                 disabled
                         ></v-text-field>
                     </v-col>
@@ -38,14 +38,42 @@
 
                         ></v-select>
                     </v-col>
+                    <v-col class="d-flex" cols="12" sm="6">
+                        <v-select
+                                :items="contexts"
+                                label="Context"
+                                :loading="loading.contexts"
+                                return-object
+                                item-value="contextId"
+                                item-text="namespace"
+                                v-model="context"
+                        ></v-select>
+                    </v-col>
                     <v-col class="d-flex" cols="12">
                         <v-text-field
-                                v-model="namespace"
-                                label="Namespace"
+                                v-model="name"
+                                label="Name"
                                 required
                         ></v-text-field>
                     </v-col>
+                    <v-col class="d-flex" cols="12" sm="6">
+                        <v-select
+                                :items="categories"
+                                label="Category"
+                                :loading="loading.categories"
+                                v-model="category"
+                        ></v-select>
+                    </v-col>
+                    <v-col class="d-flex" cols="12" sm="6">
+                        <v-select
+                                :items="scopes"
+                                label="Scope"
+                                :loading="loading.scopes"
+                                v-model="scope"
+                        ></v-select>
+                    </v-col>
                 </v-row>
+
                 <v-row>
                     <v-col class="d-flex" cols="12">
                         <v-textarea
@@ -60,11 +88,11 @@
         <v-card-actions>
             <v-spacer></v-spacer>
             <v-btn color="primary"
-                   :disabled="!namespace || !description || !organization||!unit"
-                   @click="createUnit">Create
+                   :disabled="!name || !description || !organization || !unit || !context"
+                   @click="createSchema">Create
             </v-btn>
-            <v-btn color="secondary" to="/schema"
-                   :disabled="!contextId">Create Schema
+            <v-btn color="secondary" to="/schemaVersion"
+                   :disabled="!schemaId">Create Schema Version
             </v-btn>
         </v-card-actions>
     </v-card>
@@ -77,12 +105,17 @@
     export default {
         data: () => {
             return {
-                contextId: '',
-                namespace: '',
+                schemaId: '',
+                name: '',
                 description: '',
+                category: '',
+                scope: '',
                 loading: {
                     organizations: false,
-                    units: false
+                    units: false,
+                    contexts: false,
+                    categories: false,
+                    scopes: false
                 }
             }
         },
@@ -90,15 +123,22 @@
             ...mapFields([
                 'organization',
                 'unit',
-                'context'
+                'context',
+                'schema'
             ]),
         },
         watch: {
-            namespace() {
-                this.contextId = ''
+            name() {
+                this.schemaId = ''
             },
             description() {
-                this.contextId = ''
+                this.schemaId = ''
+            },
+            category() {
+                this.schemaId = ''
+            },
+            scope() {
+                this.schemaId = ''
             }
         },
 
@@ -117,20 +157,49 @@
                 this.loading.organizations = false
                 return result
             },
+            async contexts() {
+                if (!this.organization || !this.unit) return []
+
+                this.loading.contexts = true
+                const result = await Repository.getContexts(
+                    this.organization.organizationId,
+                    this.unit.unitId
+                )
+                this.loading.contexts = false
+                return result
+            },
+            async categories() {
+                this.loading.categories = true
+                const result = await Repository.getCategories()
+                this.loading.categories = false
+                return result
+            },
+            async scopes() {
+                this.loading.scopes = true
+                const result = await Repository.getScopes()
+                this.loading.scopes = false
+                return result
+            },
         },
 
         methods: {
-            createUnit() {
+            createSchema() {
                 let vm = this
-                Repository.createContext(
+                Repository.createSchema(
                     this.organization.organizationId,
                     this.unit.unitId,
-                    this.namespace,
+                    this.context.contextId,
+                    this.name,
+                    this.scope,
+                    this.category,
                     this.description)
                     .then((created) => {
-                            vm.context = created
-                            vm.contextId = created.contextId
-                            vm.namespace = created.namespace
+                            console.log(created)
+                            vm.schema = created
+                            vm.schemaId = created.schemaId
+                            vm.name = created.name
+                            vm.scope = created.scope
+                            vm.category = created.category
                             vm.description = created.description
                         }
                     )

--- a/src/main/frontend/src/components/SchemaVersion.vue
+++ b/src/main/frontend/src/components/SchemaVersion.vue
@@ -142,7 +142,8 @@
                 'organization',
                 'unit',
                 'context',
-                'schema'
+                'schema',
+                'version'
             ]),
         },
         watch: {
@@ -219,7 +220,7 @@
                     this.previousVersion,
                     this.currentVersion)
                     .then((created) => {
-                            vm.schema = created
+                            vm.version = created
                             vm.schemaVersionId = created.schemaVersionId
                             vm.speficication = created.speficication
                             vm.description = created.description

--- a/src/main/frontend/src/components/SchemaVersion.vue
+++ b/src/main/frontend/src/components/SchemaVersion.vue
@@ -214,7 +214,7 @@
                     this.unit.unitId,
                     this.context.contextId,
                     this.schema.schemaId,
-                    this.speficication,
+                    this.specification,
                     this.description,
                     this.status,
                     this.previousVersion,

--- a/src/main/frontend/src/components/SchemaVersion.vue
+++ b/src/main/frontend/src/components/SchemaVersion.vue
@@ -219,7 +219,6 @@
                     this.previousVersion,
                     this.currentVersion)
                     .then((created) => {
-                            console.log(created)
                             vm.schema = created
                             vm.schemaVersionId = created.schemaVersionId
                             vm.speficication = created.speficication

--- a/src/main/frontend/src/router.js
+++ b/src/main/frontend/src/router.js
@@ -6,6 +6,7 @@ import Editor from '@/components/Editor'
 import Organization from '@/components/Organization'
 import Unit from '@/components/Unit'
 import Context from '@/components/Context'
+import Schema from '@/components/Schema'
 
 Vue.use(Router)
 
@@ -45,6 +46,16 @@ export default new Router({
       path: '/context',
       name: 'context',
       component: Context
+    },
+    {
+      path: '/schema',
+      name: 'schema',
+      component: Schema
+    },
+    {
+      path: '/schemaVersion',
+      name: 'schemaVersion',
+      component: e404
     },
     {
       path: '/about',

--- a/src/main/frontend/src/router.js
+++ b/src/main/frontend/src/router.js
@@ -7,63 +7,65 @@ import Organization from '@/components/Organization'
 import Unit from '@/components/Unit'
 import Context from '@/components/Context'
 import Schema from '@/components/Schema'
+import SchemaVersion from '@/components/SchemaVersion'
+
 
 Vue.use(Router)
 
 export default new Router({
-  routes: [
-    {
-      path: '/',
-      name: 'home',
-      component: Schemata
-    },
-    {
-      path: '/schemata',
-      name: 'schemata',
-      component: Schemata
-    },
-    {
-      path: '/editor',
-      name: 'editor',
-      component: Editor
-    },
-    {
-      path: '/404',
-      name: '404',
-      component: e404
-    },
-    {
-      path: '/organization',
-      name: 'organization',
-      component: Organization
-    },
-    {
-      path: '/unit',
-      name: 'unit',
-      component: Unit
-    },
-    {
-      path: '/context',
-      name: 'context',
-      component: Context
-    },
-    {
-      path: '/schema',
-      name: 'schema',
-      component: Schema
-    },
-    {
-      path: '/schemaVersion',
-      name: 'schemaVersion',
-      component: e404
-    },
-    {
-      path: '/about',
-      name: 'about',
-      // route level code-splitting
-      // this generates a separate chunk (about.[hash].js) for this route
-      // which is lazy-loaded when the route is visited.
-      component: () => import(/* webpackChunkName: "about" */ './views/About.vue')
-    }
-  ]
+    routes: [
+        {
+            path: '/',
+            name: 'home',
+            component: Schemata
+        },
+        {
+            path: '/schemata',
+            name: 'schemata',
+            component: Schemata
+        },
+        {
+            path: '/editor',
+            name: 'editor',
+            component: Editor
+        },
+        {
+            path: '/404',
+            name: '404',
+            component: e404
+        },
+        {
+            path: '/organization',
+            name: 'organization',
+            component: Organization
+        },
+        {
+            path: '/unit',
+            name: 'unit',
+            component: Unit
+        },
+        {
+            path: '/context',
+            name: 'context',
+            component: Context
+        },
+        {
+            path: '/schema',
+            name: 'schema',
+            component: Schema
+        },
+        {
+            path: '/schemaVersion',
+            name: 'schemaVersion',
+            component: SchemaVersion
+        },
+        {
+            path: '/about',
+            name: 'about',
+            // route level code-splitting
+            // this generates a separate chunk (about.[hash].js) for this route
+            // which is lazy-loaded when the route is visited.
+            component: () => import(/* webpackChunkName: "about" */ './views/About.vue')
+        }
+    ]
 })

--- a/src/test/resources/rest-api-calls.http
+++ b/src/test/resources/rest-api-calls.http
@@ -74,8 +74,8 @@ Content-Type: application/json
   "description": "Initial revision.",
   "specification": "event SchemaDefined { type eventType }",
   "status": "Published",
-  "previousVersion": "1.0.3",
-  "currentVersion": "1.0.4"
+  "previousVersion": "1.0.1",
+  "currentVersion": "1.0.0"
 }
 > {% client.global.set('schemaVersionId', response.body.schemaVersionId) %}
 

--- a/src/test/resources/rest-api-calls.http
+++ b/src/test/resources/rest-api-calls.http
@@ -74,7 +74,7 @@ Content-Type: application/json
   "description": "Initial revision.",
   "specification": "event SchemaDefined { type eventType }",
   "status": "Published",
-  "previousVersion": "1.0.1",
+  "previousVersion": "0.0.0",
   "currentVersion": "1.0.0"
 }
 > {% client.global.set('schemaVersionId', response.body.schemaVersionId) %}
@@ -94,6 +94,14 @@ Accept: application/json
 
 ### Contexts of Unit
 GET http://localhost:9019/organizations/{{orgId}}/units/{{unitId}}/contexts
+Accept: application/json
+
+### Schemata of Context
+GET http://localhost:9019/organizations/{{orgId}}/units/{{unitId}}/contexts/{{contextId}}/schemas
+Accept: application/json
+
+### Schema Versions of Schema
+GET http://localhost:9019/organizations/{{orgId}}/units/{{unitId}}/contexts/{{contextId}}/schemas/{{schemaId}}/versions
 Accept: application/json
 
 ### Categories


### PR DESCRIPTION
This completes the creation dialogs.
We can now create Orgs, Units, Contexts, Schemata and Schema Versions.

There are still some issues regarding usability (see #35 and #34) as well as some refactorings that still need to be done (see #36 and #33) as well as one validation issue in the backend (#31)

But overall, this can be demo'ed, IMHO.