### PR TITLE
Support specifying the runtime environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN cd /home/project && mvn -Pfrontend package
 FROM openjdk:8-slim
 
 ENV JAVA_OPTS=""
+ENV VLINGO_ENV="dev"
 
 COPY --from=packager "/home/project/target/vlingo-schemata-*-jar-with-dependencies.jar" "/app.jar"
 
-ENTRYPOINT exec java $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom -jar /app.jar
+ENTRYPOINT exec java $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom -jar /app.jar $VLINGO_ENV


### PR DESCRIPTION
The docker image supports switching environments with this PR.

You can now run the image by `docker run -e VLINGO_ENV=prod -p9019:9019 vlingo/vlingo-schemata` to use `src/main/resources/vlingo-schemata-prod.properties`.

`VLINGO_ENV` defaults to `dev`