### PR TITLE
Build docker image on CircleCI & push to Docker Hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,10 +34,9 @@ jobs:
     docker:
       - image: circleci/openjdk:8u151-jdk
     steps:
-      - attach_workspace:
-          at: ~/project
+      - checkout
       - setup_remote_docker:
-        docker_layer_caching: false
+          docker_layer_caching: false
       - run: docker build . -t vlingo/vlingo-schemata
       - run: |
           echo "$DOCKER_TOKEN" | docker login --username $DOCKER_USER --password-stdin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,9 +30,28 @@ jobs:
           paths:
             - ~/.m2
           key: v2-mvn-dependencies-{{ checksum "pom.xml" }}
-
+  image:
+    docker:
+      - image: circleci/openjdk:8u151-jdk
+    steps:
+      - attach_workspace:
+          at: ~/project
+      - setup_remote_docker:
+        docker_layer_caching: false
+      - run: docker build . -t vlingo/vlingo-schemata
+      - run: |
+          echo "$DOCKER_TOKEN" | docker login --username $DOCKER_USER --password-stdin
+          docker push vlingo/vlingo-schemata
 workflows:
   version: 2
   default-workflow:
     jobs:
       - build
+      - image:
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - master
+


### PR DESCRIPTION
Adds the CircleCI config to build the docker image and push it to https://hub.docker.com/r/vlingo/vlingo-schemata.

Images are only built on `master` and always tagged `:latest`.

To enable the build in CircleCI the following steps are neccessary.
However, this PR can be merged, it won't do anything if the project is not yet enabled.

* Enable the project (`Set Up Project`) in CircleCI at https://circleci.com/add-projects/gh/vlingo
* Ingore the instructions (build is already set up in `.circleci/config.yml`) and click the `Start Building` button
* Go to the project settings at https://circleci.com/gh/vlingo/vlingo-schemata/edit#env-vars and add two env vars:
  * `DOCKER_TOKEN` -> can be created at https://hub.docker.com/settings/security
  * `DOCKER_USER` -> the docker hub user 

I'm lacking the required permissions in the `vlingo` organization on Docker Hub, but I ran the same build on a fork (https://circleci.com/workflow-run/e633f1e6-2d1e-4b51-92fb-9c8078d366ea), so I'm pretty sure that works. I can also quickly set it up, if you give me access.