### PR TITLE
Enable E2E tests on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,18 +7,15 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v2-mvn-dependencies-{{ checksum "pom.xml" }}
-            - v2-mvn-dependencies-
-      - restore_cache:
-          keys:
             - v1-dependencies-{{ checksum "src/main/frontend/package.json" }}
             - v1-dependencies-
-      - run: mvn -B -Pfrontend package
+      - run: mvn -B clean package -Pfrontend
       - persist_to_workspace:
           root: ~/project
           paths:
             - target/
             - src/main/frontend/
+            - src/test/e2e/
       - store_test_results:
           path: target/surefire-reports
       - save_cache:
@@ -26,18 +23,35 @@ jobs:
             - target/node
             - src/main/frontend/node_modules
           key: v1-dependencies-{{ checksum "src/main/frontend/package.json" }}
-      - save_cache:
-          paths:
-            - ~/.m2
-          key: v2-mvn-dependencies-{{ checksum "pom.xml" }}
+  e2e-test:
+    docker:
+      - image: circleci/openjdk:8-jdk-node-browsers
+    steps:
+      - attach_workspace:
+          at: ~/project
+      - run: |
+          java -jar ~/project/target/vlingo-schemata-*-jar-with-dependencies.jar dev &
+          export CYPRESS_BASE_URL=http://localhost:9019/app
+          cd ~/project/src/test/e2e
+          npm install
+          npm run test-multiple
+      - store_test_results:
+          path: src/test/e2e/multiple-results
+      - store_artifacts:
+          path: src/test/e2e/cypress/videos
+          destination: videos
+      - store_artifacts:
+          path: src/test/e2e/cypress/screenshots
+          destination: screenshots
   image:
     docker:
-      - image: circleci/openjdk:8u151-jdk
+      - image: circleci/jdk:8
     steps:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: false
-      - run: docker build . -t vlingo/vlingo-schemata
+      - run: |
+          docker build . -t vlingo/vlingo-schemata
       - run: |
           echo "$DOCKER_TOKEN" | docker login --username $DOCKER_USER --password-stdin
           docker push vlingo/vlingo-schemata
@@ -46,11 +60,15 @@ workflows:
   default-workflow:
     jobs:
       - build
-      - image:
+      - e2e-test:
           requires:
             - build
+      - image:
+          requires:
+            - e2e-test
           filters:
             branches:
               only:
                 - master
+
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM maven:3.6.2-jdk-8-slim as packager
 # RUN cd /home/project && mvn dependency:go-offline -B
 
 ADD . /home/project
-RUN cd /home/project && mvn clean -Pfrontend package
+RUN cd /home/project && mvn -B clean -Pfrontend package
 
 # Second stage: Create runtime image
 FROM openjdk:8-jdk-alpine

--- a/src/test/e2e/.gitignore
+++ b/src/test/e2e/.gitignore
@@ -1,0 +1,3 @@
+cypress/screenshots/
+cypress/videos/
+multiple-results/results.xml

--- a/src/test/e2e/config.json
+++ b/src/test/e2e/config.json
@@ -1,0 +1,6 @@
+{
+  "reporterEnabled": "spec, mocha-junit-reporter",
+  "mochaJunitReporterReporterOptions": {
+    "mochaFile": "multiple-results/results.xml"
+  }
+}

--- a/src/test/e2e/cypress.json
+++ b/src/test/e2e/cypress.json
@@ -1,1 +1,6 @@
-{}
+{
+  "baseUrl": "http://localhost:9019/app",
+  "numTestsKeptInMemory": 1,
+  "chromeWebSecurity": false,
+  "video": true
+}

--- a/src/test/e2e/cypress/integration/entity-creation.spec.ts
+++ b/src/test/e2e/cypress/integration/entity-creation.spec.ts
@@ -137,9 +137,9 @@ describe('Entity Creation Tests', function () {
         cy.fillEditor('#description-editor', faker.lorem.sentence())
         cy.fillEditor('#specification-editor', 'event SalutationHappened {\n' +
             '    type eventType')
-        cy.wait(250).contains('button', 'Create').click({force: true})
+        cy.contains('button', 'Create').click()
 
-        cy.wait(250).fieldContent('SchemaVersionID').should('not.be.empty')
+        cy.fieldContent('SchemaVersionID').should('not.be.empty')
     });
 
 });

--- a/src/test/e2e/package-lock.json
+++ b/src/test/e2e/package-lock.json
@@ -1434,6 +1434,11 @@
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
+    },
     "browserify-aes": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
@@ -1613,6 +1618,11 @@
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       }
+    },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
     },
     "check-more-types": {
       "version": "2.24.0",
@@ -1951,6 +1961,11 @@
         "which": "^1.2.9"
       }
     },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
+    },
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
@@ -2118,6 +2133,11 @@
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
       }
+    },
+    "diff": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
     },
     "diffie-hellman": {
       "version": "5.0.3",
@@ -3157,6 +3177,11 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
       "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q=="
     },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -3254,6 +3279,11 @@
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
       }
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -3852,6 +3882,16 @@
         "object-visit": "^1.0.0"
       }
     },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "requires": {
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
+      }
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -3974,6 +4014,105 @@
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
+      }
+    },
+    "mocha": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+      "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "requires": {
+            "has-flag": "^2.0.0"
+          }
+        }
+      }
+    },
+    "mocha-junit-reporter": {
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/mocha-junit-reporter/-/mocha-junit-reporter-1.23.1.tgz",
+      "integrity": "sha512-qeDvKlZyAH2YJE1vhryvjUQ06t2hcnwwu4k5Ddwn0GQINhgEYFhlGM0DwYCVUHq5cuo32qAW6HDsTHt7zz99Ng==",
+      "requires": {
+        "debug": "^2.2.0",
+        "md5": "^2.1.0",
+        "mkdirp": "~0.5.1",
+        "strip-ansi": "^4.0.0",
+        "xml": "^1.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
+    "mocha-multi-reporters": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/mocha-multi-reporters/-/mocha-multi-reporters-1.1.7.tgz",
+      "integrity": "sha1-zH8/TTL0eFIJQdhSq7ZNmYhYfYI=",
+      "requires": {
+        "debug": "^3.1.0",
+        "lodash": "^4.16.4"
       }
     },
     "moment": {
@@ -5726,6 +5865,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
     },
     "xtend": {
       "version": "4.0.2",

--- a/src/test/e2e/package.json
+++ b/src/test/e2e/package.json
@@ -10,11 +10,15 @@
     "faker": "^4.1.0",
     "ts-loader": "^6.1.2",
     "typescript": "^3.6.3",
-    "webpack": "^4.41.0"
+    "webpack": "^4.41.0",
+    "mocha": "^4.0.1",
+    "mocha-junit-reporter": "^1.13.0",
+    "mocha-multi-reporters": "^1.1.4"
   },
   "devDependencies": {},
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test-junit": "npx cypress run --reporter junit --reporter-options 'mochaFile=junit-results/my-test-output.xml' --spec \"cypress/integration/*.spec.ts\"",
+    "test-multiple": "npx cypress run --reporter mocha-multi-reporters --reporter-options configFile=config.json --spec \"cypress/integration/*.spec.ts\""
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Enables ...

* ... starting the server built in previous build steps,
* ... running the E2E tests against it,
* ... displaying the test results & screenshots of failed tests in CircleCI and
* ... making videos of the test runs available on CircleCI

It also disables as many `.m2` caches as it can (within CircleCI and in Docker layers) b/c of the non `-SNAPSHOT` versioning scheme. Once this is in place, we should re-enable caching to get _much_ faster builds.

Closes #32 