### PR TITLE
Allow for retrieving Java code for schemas via the http API

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,8 @@ services:
     ports:
       - '5432:5432'
     environment:
-      POSTGRES_USER: vlingo_schemata
+      POSTGRES_DB: vlingo_schemata
+      POSTGRES_USER: vlingo_test
       POSTGRES_PASSWORD: vlingo123
 
 volumes:

--- a/src/main/java/io/vlingo/schemata/infra/persistence/PostgresSchemataObjectStore.java
+++ b/src/main/java/io/vlingo/schemata/infra/persistence/PostgresSchemataObjectStore.java
@@ -48,8 +48,8 @@ public class PostgresSchemataObjectStore extends SchemataObjectStore {
       jdbi.handle().execute("CREATE UNIQUE INDEX IF NOT EXISTS UNIT_PARENT_INDEX ON TBL_UNITS (organizationId)");
       jdbi.handle().execute("CREATE UNIQUE INDEX IF NOT EXISTS UNIT_ALL_INDEX ON TBL_UNITS (organizationId, unitId)");
 
-    jdbi.handle().execute("ALTER TABLE TBL_UNITS DROP CONSTRAINT IF EXISTS UNIT_ALL_UNIQUE");
-    jdbi.handle().execute("ALTER TABLE TBL_UNITS ADD CONSTRAINT UNIT_ALL_UNIQUE UNIQUE (organizationId, name)");
+      jdbi.handle().execute("ALTER TABLE TBL_UNITS DROP CONSTRAINT IF EXISTS UNIT_ALL_UNIQUE");
+      jdbi.handle().execute("ALTER TABLE TBL_UNITS ADD CONSTRAINT UNIT_ALL_UNIQUE UNIQUE (organizationId, name)");
   }
 
   @Override

--- a/src/main/java/io/vlingo/schemata/infra/persistence/PostgresSchemataObjectStore.java
+++ b/src/main/java/io/vlingo/schemata/infra/persistence/PostgresSchemataObjectStore.java
@@ -20,10 +20,17 @@ public class PostgresSchemataObjectStore extends SchemataObjectStore {
               "name VARCHAR(128) NOT NULL, " +
               "description VARCHAR(8000) " +
 
-              "UNIQUE (name) " +
               ")");
 
       jdbi.handle().execute("CREATE UNIQUE INDEX IF NOT EXISTS ORG_ALL_INDEX ON TBL_ORGANIZATIONS (organizationId)");
+
+      /*
+      Dropping the constraint and recreating it afterwards is not an optimal solution once we have actual data.
+
+      TODO: Refactor to find out if constraint already exists or switch to a schema migration tool like flyway or liquibase
+       */
+      jdbi.handle().execute("ALTER TABLE TBL_ORGANIZATIONS DROP CONSTRAINT IF EXISTS ORGANIZATION_UNIQUE");
+      jdbi.handle().execute("ALTER TABLE TBL_ORGANIZATIONS ADD CONSTRAINT ORGANIZATION_UNIQUE UNIQUE (name)");
   }
 
   @Override
@@ -36,11 +43,13 @@ public class PostgresSchemataObjectStore extends SchemataObjectStore {
               "name VARCHAR(128) NOT NULL, " +
               "description VARCHAR(8000) " +
 
-              "UNIQUE (organizationId, name) " +
               ")");
 
       jdbi.handle().execute("CREATE UNIQUE INDEX IF NOT EXISTS UNIT_PARENT_INDEX ON TBL_UNITS (organizationId)");
       jdbi.handle().execute("CREATE UNIQUE INDEX IF NOT EXISTS UNIT_ALL_INDEX ON TBL_UNITS (organizationId, unitId)");
+
+    jdbi.handle().execute("ALTER TABLE TBL_UNITS DROP CONSTRAINT IF EXISTS UNIT_ALL_UNIQUE");
+    jdbi.handle().execute("ALTER TABLE TBL_UNITS ADD CONSTRAINT UNIT_ALL_UNIQUE UNIQUE (organizationId, name)");
   }
 
   @Override
@@ -54,11 +63,13 @@ public class PostgresSchemataObjectStore extends SchemataObjectStore {
               "namespace VARCHAR(256) NOT NULL, " +
               "description VARCHAR(8000) " +
 
-              "UNIQUE (unitId, namespace) " +
               ")");
 
       jdbi.handle().execute("CREATE UNIQUE INDEX IF NOT EXISTS CONTEXT_PARENT_INDEX ON TBL_CONTEXTS (organizationId, unitId)");
       jdbi.handle().execute("CREATE UNIQUE INDEX IF NOT EXISTS CONTEXT_ALL_INDEX ON TBL_CONTEXTS (organizationId, unitId, contextId)");
+
+      jdbi.handle().execute("ALTER TABLE TBL_CONTEXTS DROP CONSTRAINT IF EXISTS CONTEXT_ALL_UNIQUE");
+      jdbi.handle().execute("ALTER TABLE TBL_CONTEXTS ADD CONSTRAINT CONTEXT_ALL_UNIQUE UNIQUE (organizationId, unitId, namespace)");
   }
 
   @Override
@@ -75,11 +86,14 @@ public class PostgresSchemataObjectStore extends SchemataObjectStore {
               "name VARCHAR(128) NOT NULL, " +
               "description VARCHAR(8000) " +
 
-              "UNIQUE (contextId, category, name) " +
               ")");
 
       jdbi.handle().execute("CREATE UNIQUE INDEX IF NOT EXISTS SCHEMA_PARENT_INDEX ON TBL_SCHEMAS (organizationId, unitId, contextId)");
       jdbi.handle().execute("CREATE UNIQUE INDEX IF NOT EXISTS SCHEMA_ALL_INDEX ON TBL_SCHEMAS (organizationId, unitId, contextId, schemaId)");
+
+      jdbi.handle().execute("ALTER TABLE TBL_SCHEMAS DROP CONSTRAINT IF EXISTS SCHEMA_ALL_UNIQUE");
+      jdbi.handle().execute("ALTER TABLE TBL_SCHEMAS ADD CONSTRAINT SCHEMA_ALL_UNIQUE UNIQUE (organizationId, unitId, contextId, name)");
+
   }
 
   @Override
@@ -112,11 +126,13 @@ public class PostgresSchemataObjectStore extends SchemataObjectStore {
               "previousVersion VARCHAR(20) NOT NULL, " +
               "currentVersion VARCHAR(20) NOT NULL " +
 
-              "UNIQUE (schemaId, currentVersion) " +
               ")");
 
       jdbi.handle().execute("CREATE UNIQUE INDEX IF NOT EXISTS SCHEMAVERSION_PARENT_INDEX ON TBL_SCHEMAVERSIONS (organizationId, unitId, contextId, schemaId)");
       jdbi.handle().execute("CREATE UNIQUE INDEX IF NOT EXISTS SCHEMAVERSION_ALL_INDEX ON TBL_SCHEMAVERSIONS (organizationId, unitId, contextId, schemaId, schemaVersionId)");
+
+      jdbi.handle().execute("ALTER TABLE TBL_SCHEMAVERSIONS DROP CONSTRAINT IF EXISTS SCHEMAVERSIION_ALL_UNIQUE");
+      jdbi.handle().execute("ALTER TABLE TBL_SCHEMAVERSIONS ADD CONSTRAINT SCHEMAVERSIION_ALL_UNIQUE UNIQUE (organizationId, unitId, contextId, schemaId, currentVersion)");
   }
 
   @Override

--- a/src/test/resources/rest-api-calls.http
+++ b/src/test/resources/rest-api-calls.http
@@ -109,3 +109,86 @@ GET http://localhost:9019/schema/categories
 Accept: application/json
 
 ###
+
+
+// Reproduce https://github.com/vlingo/vlingo-schemata/issues/55
+POST http://localhost:9019/organizations
+Content-Type: application/json
+
+{
+  "organizationId": "",
+  "name": "org",
+  "description": "My organization."
+}
+> {% client.global.set('orgId', response.body.organizationId) %}
+
+
+### Create Unit
+POST  http://localhost:9019/organizations/{{orgId}}/units
+Content-Type: application/json
+
+{
+  "organizationId": "{{orgId}}",
+  "unitId": "",
+  "name": "unit",
+  "description": "My unit."
+}
+
+> {% client.global.set('unitId', response.body.unitId) %}
+
+### Create Context
+POST http://localhost:9019/organizations/{{orgId}}/units/{{unitId}}/contexts
+Content-Type: application/json
+
+{
+  "organizationId": "{{orgId}}",
+  "unitId": "{{unitId}}",
+  "contextId": "",
+  "namespace": "context",
+  "description": "Schemata Context."
+}
+
+> {% client.global.set('contextId', response.body.contextId) %}
+
+### Create Schema
+POST http://localhost:9019/organizations/{{orgId}}/units/{{unitId}}/contexts/{{contextId}}/schemas
+Content-Type: application/json
+
+{
+  "organizationId": "{{orgId}}",
+  "unitId": "{{unitId}}",
+  "contextId": "{{contextId}}",
+  "schemaId": "",
+  "category": "Event",
+  "name": "SchemaDefinedFoo",
+  "scope": "Private",
+  "description": "Schemata was defined event."
+}
+
+> {% client.global.set('schemaId', response.body.schemaId) %}
+
+
+### Create Schema Version
+POST http://localhost:9019/organizations/{{orgId}}/units/{{unitId}}/contexts/{{contextId}}/schemas/{{schemaId}}/versions
+Content-Type: application/json
+
+{
+  "organizationId": "{{orgId}}",
+  "unitId": "{{unitId}}",
+  "contextId": "{{contextId}}",
+  "schemaId": "{{schemaId}}",
+  "schemaVersionId": "",
+  "description": "Initial revision.",
+  "specification": "event SchemaDefined { type eventType }",
+  "status": "Published",
+  "previousVersion": "0.0.0",
+  "currentVersion": "1.0.0"
+}
+> {% client.global.set('schemaVersionId', response.body.schemaVersionId) %}
+
+
+### this crashes the compiler
+GET http://localhost:9019/code/org:unit:context:schema:1.0.0/java
+Accept: application/json
+
+###

--- a/src/test/resources/rest-api-calls.http
+++ b/src/test/resources/rest-api-calls.http
@@ -160,7 +160,7 @@ Content-Type: application/json
   "contextId": "{{contextId}}",
   "schemaId": "",
   "category": "Event",
-  "name": "SchemaDefinedFoo",
+  "name": "schema",
   "scope": "Private",
   "description": "Schemata was defined event."
 }


### PR DESCRIPTION
Makes it possible to retrieve Java code from `CodeResource`.
Please note that this disables the authentication checks by providing a matching fake auth if none is given. All workaround related sections in the code are marked w/ `FIXME` comments.

Relates to #55.