### PR TITLE
Add refresh button to schemata view

### DIFF
--- a/src/main/frontend/src/components/Schemata.vue
+++ b/src/main/frontend/src/components/Schemata.vue
@@ -1,14 +1,16 @@
 <template xmlns:v-slot="http://www.w3.org/1999/XSL/Transform">
 <v-card height="45vh" id="schemata-treeview">
-  <v-card-title>
+  <v-toolbar dense>
     <v-text-field
-      v-model="search"
-      label="Search"
-      clearable
-      hide-details
-      :clear-icon="icons.clear"
-    ></v-text-field>
-  </v-card-title>
+          v-model="search"
+          label="Search"
+          clearable
+          hide-details
+          :clear-icon="icons.clear"
+  ></v-text-field>
+    <v-spacer></v-spacer>
+    <v-btn small icon @click="refresh"><v-icon>{{ icons.refresh }}</v-icon></v-btn>
+  </v-toolbar>
   <v-card-text>
     <v-treeview
       dense
@@ -53,7 +55,8 @@ import {
   mdiFileDocument,
   mdiHelpCircle,
   mdiPencil,
-  mdiPlaylistPlay
+  mdiPlaylistPlay,
+  mdiRefresh
 } from '@mdi/js'
 
 export default {
@@ -64,6 +67,7 @@ export default {
     icons: {
       close: mdiClose,
       edit: mdiPencil,
+      refresh: mdiRefresh,
       categories: {
         Command: mdiCogs,
         Data: mdiDatabase,
@@ -85,6 +89,10 @@ export default {
     }
   },
   methods: {
+    refresh() {
+      this.items = []
+      this.loadOrganizations()
+    },
     loadOrganizations() {
       let vm = this
       Repository.getOrganizations()

--- a/src/main/frontend/src/components/Schemata.vue
+++ b/src/main/frontend/src/components/Schemata.vue
@@ -9,7 +9,7 @@
           :clear-icon="icons.clear"
   ></v-text-field>
     <v-spacer></v-spacer>
-    <v-btn small icon @click="refresh"><v-icon>{{ icons.refresh }}</v-icon></v-btn>
+    <v-btn small icon @click="refresh" id="button-refresh-schemata-tree"><v-icon>{{ icons.refresh }}</v-icon></v-btn>
   </v-toolbar>
   <v-card-text>
     <v-treeview

--- a/src/main/frontend/src/components/Schemata.vue
+++ b/src/main/frontend/src/components/Schemata.vue
@@ -1,6 +1,6 @@
 <template xmlns:v-slot="http://www.w3.org/1999/XSL/Transform">
 <v-card height="45vh" id="schemata-treeview">
-  <v-toolbar dense>
+  <v-toolbar >
     <v-text-field
           v-model="search"
           label="Search"
@@ -9,7 +9,7 @@
           :clear-icon="icons.clear"
   ></v-text-field>
     <v-spacer></v-spacer>
-    <v-btn small icon @click="refresh" id="button-refresh-schemata-tree"><v-icon>{{ icons.refresh }}</v-icon></v-btn>
+    <v-btn icon @click="refresh" id="button-refresh-schemata-tree"><v-icon>{{ icons.refresh }}</v-icon></v-btn>
   </v-toolbar>
   <v-card-text>
     <v-treeview

--- a/src/test/e2e/cypress/integration/browse-schemata.spec.ts
+++ b/src/test/e2e/cypress/integration/browse-schemata.spec.ts
@@ -11,6 +11,7 @@ describe('Schemata View Tests', function () {
     });
 
     it('can browse schemata', function () {
+        this.skip();
         cy.task('schemata:withTestData').then(testData => {
             let data = <Cypress.SchemataTestData><unknown>testData
             cy.visit("/#/schemata")
@@ -27,7 +28,16 @@ describe('Schemata View Tests', function () {
             cy.contains('.v-tab', 'Description').click()
             cy.editorContent('#description-editor').should('contain', data.version.description)
         })
+    });
 
-
+    it('can refresh schemata', function () {
+        cy.visit("/#/schemata")
+        cy.task('schemata:withTestData').then(testData => {
+            let data = <Cypress.SchemataTestData><unknown>testData
+            cy.fillField('Search', data.organization.name)
+            cy.get(`.v-treeview-node__label:contains(${data.organization.name})`).should('not.exist')
+            cy.get('#button-refresh-schemata-tree').click()
+            cy.get(`.v-treeview-node__label:contains(${data.organization.name})`).should('exist')
+        })
     });
 });

--- a/src/test/e2e/cypress/integration/browse-schemata.spec.ts
+++ b/src/test/e2e/cypress/integration/browse-schemata.spec.ts
@@ -11,7 +11,6 @@ describe('Schemata View Tests', function () {
     });
 
     it('can browse schemata', function () {
-        this.skip();
         cy.task('schemata:withTestData').then(testData => {
             let data = <Cypress.SchemataTestData><unknown>testData
             cy.visit("/#/schemata")


### PR DESCRIPTION
Adds a refresh button to the schemata treeview that reloads all organizations.

Closes #99 

![image](https://user-images.githubusercontent.com/189410/70323442-0e41a700-182d-11ea-9995-8804f983c1e7.png)
