### PR TITLE
Allow for pushing new schema versions

### DIFF
--- a/src/main/java/io/vlingo/schemata/Bootstrap.java
+++ b/src/main/java/io/vlingo/schemata/Bootstrap.java
@@ -92,6 +92,15 @@ public class Bootstrap {
     return instance;
   }
 
+  void stopServer() throws Exception {
+    if (instance == null) {
+      throw new IllegalStateException("Schemata server not running");
+    }
+    instance.server.stop();
+  }
+
+
+
   public static void main(final String[] args) throws Exception {
     System.out.println("=========================");
     System.out.println("service: vlingo-schemata.");

--- a/src/main/java/io/vlingo/schemata/Schemata.java
+++ b/src/main/java/io/vlingo/schemata/Schemata.java
@@ -37,6 +37,8 @@ public class Schemata {
 
   public static final String SchemaVersionsPath = "/organizations/%s/units/%s/contexts/%s/schemas/%s/versions/%s";
 
+  public static final String CodePath = "/code/%s/%s";
+
   //==========================
   // Names
   //==========================

--- a/src/main/java/io/vlingo/schemata/Schemata.java
+++ b/src/main/java/io/vlingo/schemata/Schemata.java
@@ -17,10 +17,11 @@ public class Schemata {
   public static final String ReferenceSeparator = ":";
 
   /**
-   * Minimum number of parts specified in a reference.
+   * Number of parts specified in a reference.
    * (organization, unit, context, schema, [schemaVersion])
    */
   public static final int MinReferenceParts = 4;
+  public static final int MaxReferenceParts = 5;
 
   //==========================
   // Paths

--- a/src/main/java/io/vlingo/schemata/codegen/backend/java/JavaBackend.java
+++ b/src/main/java/io/vlingo/schemata/codegen/backend/java/JavaBackend.java
@@ -79,7 +79,7 @@ public class JavaBackend extends Actor implements Backend {
         ;
 
         final MethodSpec constructor = MethodSpec.constructorBuilder()
-                .addModifiers(Modifier.FINAL, Modifier.PUBLIC)
+                .addModifiers(Modifier.PUBLIC)
                 .addParameters(fields.stream().filter(field -> !(field.type instanceof ComputableType)).map(this::toConstructorParameter).collect(Collectors.toList()))
                 .addCode(CodeBlock.join(initializers, "\n"))
                 .build();

--- a/src/main/java/io/vlingo/schemata/model/FullyQualifiedReference.java
+++ b/src/main/java/io/vlingo/schemata/model/FullyQualifiedReference.java
@@ -1,0 +1,71 @@
+// Copyright © 2012-2018 Vaughn Vernon. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+
+package io.vlingo.schemata.model;
+
+import io.vlingo.schemata.Schemata;
+
+import java.util.Arrays;
+
+public class FullyQualifiedReference {
+
+    public final String organization;
+    public final String unit;
+    public final String context;
+    public final String schema;
+    public final String schemaVersion;
+
+    public static FullyQualifiedReference identity(final String organization, final String unit, final String context, final String schema, final String schemaVersion) {
+        return new FullyQualifiedReference(organization, unit, context, schema, schemaVersion);
+    }
+
+    public static FullyQualifiedReference from(String reference) {
+        String[] parts = reference.split(Schemata.ReferenceSeparator);
+
+        ensureValidReference(parts);
+
+        if (parts.length > Schemata.MinReferenceParts) {
+            return new FullyQualifiedReference(parts[0], parts[1], parts[2], parts[3], parts[4]);
+        } else {
+            return new FullyQualifiedReference(parts[0], parts[1], parts[2], parts[3]);
+        }
+
+    }
+
+    public boolean isSchemaVersionReference() {
+        return this.schemaVersion != null;
+    }
+
+    private static void ensureValidReference(String[] parts) {
+
+        if (!Arrays.stream(parts).allMatch(p -> p.length() > 0)) {
+            throw new IllegalArgumentException(
+                    "Invalid reference. Organization, Unit, Context and Schema parts must be set to non empty values.");
+        }
+
+        if (parts.length < Schemata.MinReferenceParts || parts.length > Schemata.MaxReferenceParts) {
+            throw new IllegalArgumentException(
+                    "Invalid reference. Valid references look like <org>:<unit>:<context>:<schema>[:<version>]");
+        }
+    }
+
+    private FullyQualifiedReference(final String organization, final String unit, final String context, final String schema) {
+        this.organization = organization;
+        this.unit = unit;
+        this.context = context;
+        this.schema = schema;
+        this.schemaVersion = null;
+    }
+
+    private FullyQualifiedReference(final String organization, final String unit, final String context, final String schema, final String schemaVersion) {
+        this.organization = organization;
+        this.unit = unit;
+        this.context = context;
+        this.schema = schema;
+        this.schemaVersion = schemaVersion;
+    }
+}

--- a/src/main/java/io/vlingo/schemata/model/FullyQualifiedReference.java
+++ b/src/main/java/io/vlingo/schemata/model/FullyQualifiedReference.java
@@ -68,4 +68,12 @@ public class FullyQualifiedReference {
         this.schema = schema;
         this.schemaVersion = schemaVersion;
     }
+
+    @Override
+    public String toString() {
+        String ref = String.join(Schemata.ReferenceSeparator, organization, unit, context, schema);
+        return isSchemaVersionReference()
+                ? String.join(Schemata.ReferenceSeparator, ref, schemaVersion)
+                : ref;
+    }
 }

--- a/src/main/java/io/vlingo/schemata/query/SchemaQueries.java
+++ b/src/main/java/io/vlingo/schemata/query/SchemaQueries.java
@@ -16,4 +16,5 @@ public interface SchemaQueries {
   Completes<List<SchemaData>> schemas(final String organizationId, final String unitId, final String contextId);
   Completes<SchemaData> schema(final String organizationId, final String unitId, final String contextId, final String schemaId);
   Completes<SchemaData> schemaNamed(final String organizationId, final String unitId, final String contextId, final String name);
+  Completes<SchemaData> schemaVersionByNames(final String organization, final String unit, final String context, final String schema);
 }

--- a/src/main/java/io/vlingo/schemata/query/SchemaQueriesActor.java
+++ b/src/main/java/io/vlingo/schemata/query/SchemaQueriesActor.java
@@ -34,6 +34,14 @@ public class SchemaQueriesActor extends StateObjectQueryActor implements SchemaQ
             "AND contextId = :contextId " +
             "AND name = :name";
 
+  private static final String ByNames =
+          "SELECT s.* FROM TBL_ORGANIZATIONS AS o " +
+            "JOIN TBL_UNITS AS u ON u.organizationId = o.organizationId " +
+            "JOIN TBL_CONTEXTS AS c ON c.unitId = u.unitId " +
+            "JOIN TBL_SCHEMAS AS s ON s.contextId = c.contextId " +
+            "WHERE o.name = :organization AND u.name = :unit AND c.namespace = :context AND s.name = :schema";
+
+
   private final Map<String,String> parameters;
 
   public SchemaQueriesActor(final ObjectStore objectStore) {
@@ -80,6 +88,17 @@ public class SchemaQueriesActor extends StateObjectQueryActor implements SchemaQ
     parameters.put("name", name);
 
     return queryOne(ByName, parameters);
+  }
+
+  @Override
+  public Completes<SchemaData> schemaVersionByNames(String organization, String unit, String context, String schema) {
+    parameters.clear();
+    parameters.put("organization", organization);
+    parameters.put("unit", unit);
+    parameters.put("context", context);
+    parameters.put("schema", schema);
+
+    return queryOne(ByNames, parameters);
   }
 
   private Completes<SchemaData> queryOne(final String query, final Map<String,String> parameters) {

--- a/src/test/java/io/vlingo/schemata/codegen/specs/JavaCodeGenTests.java
+++ b/src/test/java/io/vlingo/schemata/codegen/specs/JavaCodeGenTests.java
@@ -29,7 +29,7 @@ public class JavaCodeGenTests extends CodeGenTests {
     assertTrue(result.contains("public final SchemaVersion.Version eventVersion;"));
     assertTrue(result.contains("public final String toWhom;"));
     assertTrue(result.contains("public final String text;"));
-    assertTrue(result.contains("public final SalutationHappened(final String toWhom, final String text) {"));
+    assertTrue(result.contains("public SalutationHappened(final String toWhom, final String text) {"));
     assertTrue(result.contains("this.eventType = \"SalutationHappened\";"));
     assertTrue(result.contains("this.occurredOn = System.currentTimeMillis();"));
     assertTrue(result.contains("this.eventVersion = SchemaVersion.Version.of(\"0.0.1\");"));
@@ -64,7 +64,7 @@ public class JavaCodeGenTests extends CodeGenTests {
     assertTrue(result.contains("public final SchemaVersion.Version eventVersion;"));
     assertTrue(result.contains("public final Price oldPrice;"));
     assertTrue(result.contains("public final Price newPrice;"));
-    assertTrue(result.contains("public final PriceChanged(final Price oldPrice, final Price newPrice) {"));
+    assertTrue(result.contains("public PriceChanged(final Price oldPrice, final Price newPrice) {"));
     assertTrue(result.contains("this.occurredOn = System.currentTimeMillis();"));
     assertTrue(result.contains("this.eventVersion = SchemaVersion.Version.of(\"0.5.1\");"));
     assertTrue(result.contains("this.oldPrice = oldPrice;"));

--- a/src/test/java/io/vlingo/schemata/model/FullyQualifiedReferenceTest.java
+++ b/src/test/java/io/vlingo/schemata/model/FullyQualifiedReferenceTest.java
@@ -1,0 +1,54 @@
+package io.vlingo.schemata.model;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class FullyQualifiedReferenceTest {
+
+    @Test
+    public void schemaReferenceCanBeProducedFromReferenceString() {
+        String refStr = "org:unit:context:schema";
+        FullyQualifiedReference ref = FullyQualifiedReference.from(refStr);
+
+        assertEquals("org", ref.organization);
+        assertEquals("unit", ref.unit);
+        assertEquals("context", ref.context);
+        assertEquals("schema", ref.schema);
+
+        assertFalse(ref.isSchemaVersionReference());
+    }
+
+    @Test
+    public void schemaVersionReferenceCanBeProducedFromReferenceString() {
+        String refStr = "org:unit:context:schema:0.1.1";
+        FullyQualifiedReference ref = FullyQualifiedReference.from(refStr);
+
+        assertEquals("org", ref.organization);
+        assertEquals("unit", ref.unit);
+        assertEquals("context", ref.context);
+        assertEquals("schema", ref.schema);
+        assertEquals("0.1.1", ref.schemaVersion);
+
+        assertTrue(ref.isSchemaVersionReference());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void incompleteReferencesCannotBeCreated() {
+        String refStr = "org:unit:context";
+        FullyQualifiedReference.from(refStr);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void referencesWithEmptyPartsCannotBeCreated() {
+        String refStr = "org:unit::schema";
+        FullyQualifiedReference.from(refStr);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void referencesWithTooManyPartsCannotBeCreated() {
+        String refStr = "org:unit:context:schema:0.0.0:invalid";
+        FullyQualifiedReference.from(refStr);
+    }
+
+}

--- a/src/test/java/io/vlingo/schemata/resource/JavaCodeResourceTest.java
+++ b/src/test/java/io/vlingo/schemata/resource/JavaCodeResourceTest.java
@@ -42,7 +42,7 @@ public class JavaCodeResourceTest extends ResourceTest {
             "import io.vlingo.lattice.model.DomainEvent;\n" +
             "\n" +
             "public final class SchemaDefined extends DomainEvent {\n" +
-            "  public final SchemaDefined() {\n" +
+            "  public SchemaDefined() {\n" +
             "  }\n" +
             "}\n"));
   }

--- a/src/test/resources/schemata-demo.http
+++ b/src/test/resources/schemata-demo.http
@@ -75,3 +75,9 @@ Content-Type: application/json
 }
 
 > {% client.global.set('schemaVersionId', response.body.schemaVersionId) %}
+
+### Pull code by reference
+GET http://localhost:9019/code/Vlingo:schemata:io.vlingo.schemata:SchemaDefined:0.0.1/java
+Accept: application/json
+
+###

--- a/src/test/resources/schemata-demo.http
+++ b/src/test/resources/schemata-demo.http
@@ -1,0 +1,77 @@
+# Schema Definitions
+
+## Create master data
+
+### Create Organization
+POST http://localhost:9019/organizations
+Content-Type: application/json
+
+{
+  "organizationId": "",
+  "name": "Vlingo",
+  "description": "Vlingo Organization"
+}
+
+> {% client.global.set('orgId', response.body.organizationId) %}
+
+
+### Create Unit
+POST  http://localhost:9019/organizations/{{orgId}}/units
+Content-Type: application/json
+
+{
+  "organizationId": "{{orgId}}",
+  "unitId": "",
+  "name": "schemata",
+  "description": "Schemata Unit"
+}
+
+> {% client.global.set('unitId', response.body.unitId) %}
+
+### Create Context
+POST http://localhost:9019/organizations/{{orgId}}/units/{{unitId}}/contexts
+Content-Type: application/json
+
+{
+  "organizationId": "{{orgId}}",
+  "unitId": "{{unitId}}",
+  "contextId": "",
+  "namespace": "io.vlingo.schemata",
+  "description": "Schemata Context"
+}
+
+> {% client.global.set('contextId', response.body.contextId) %}
+
+### Create Schema
+POST http://localhost:9019/organizations/{{orgId}}/units/{{unitId}}/contexts/{{contextId}}/schemas
+Content-Type: application/json
+
+{
+  "organizationId": "{{orgId}}",
+  "unitId": "{{unitId}}",
+  "contextId": "{{contextId}}",
+  "schemaId": "",
+  "category": "Event",
+  "name": "SchemaDefined",
+  "scope": "Public",
+  "description": "Fired whenever a new schema is defined."
+}
+
+> {% client.global.set('schemaId', response.body.schemaId) %}
+
+
+###
+## Demo starts here
+
+### Push schema by reference
+
+POST http://localhost:9019/versions/Vlingo:schemata:io.vlingo.schemata:SchemaDefined:0.0.1
+Content-Type: application/json
+
+{
+  "description": "Updated revision.",
+  "specification": "event SchemaDefined { type eventType }",
+  "previousVersion": "0.0.0"
+}
+
+> {% client.global.set('schemaVersionId', response.body.schemaVersionId) %}


### PR DESCRIPTION
Adds operation to push a new schema version using the fully qualified reference, e.g.

```
POST http://localhost:9019/versions/Vlingo:schemata:io.vlingo.schemata:SchemaDefined:0.0.1
Content-Type: application/json

{
  "description": "Updated revision.",
  "specification": "event SchemaDefined { type eventType }",
  "previousVersion": "0.0.0"
}
```

Focuses on the happy path for the demo, we should review error handling later on.

Part of #105