### PR TITLE
Support pulling schema versions by reference

### DIFF
--- a/src/main/java/io/vlingo/schemata/query/SchemaVersionQueriesActor.java
+++ b/src/main/java/io/vlingo/schemata/query/SchemaVersionQueriesActor.java
@@ -202,6 +202,8 @@ public class SchemaVersionQueriesActor extends StateObjectQueryActor implements 
   private Completes<SchemaVersionData> queryOne(final String query, final Map<String,String> parameters) {
     final QueryExpression expression = MapQueryExpression.using(SchemaVersionState.class, query, parameters);
 
-    return queryObject(SchemaVersionState.class, expression, (SchemaVersionState state) -> SchemaVersionData.from(state));
+    return queryObject(SchemaVersionState.class, expression, (SchemaVersionState state) -> state == null
+      ? SchemaVersionData.none()
+      : SchemaVersionData.from(state));
   }
 }

--- a/src/main/java/io/vlingo/schemata/resource/SchemaVersionResource.java
+++ b/src/main/java/io/vlingo/schemata/resource/SchemaVersionResource.java
@@ -215,7 +215,17 @@ public class SchemaVersionResource extends ResourceHandler {
           fqr.context,
           fqr.schema,
           fqr.schemaVersion)
-          .andThenTo(schemaVersionData -> Completes.withSuccess(Response.of(Ok, serialized(schemaVersionData))));
+          .andThenTo(schemaVersionData -> schemaVersionData.isNone()
+                ? Completes.withSuccess(
+                    Response.of(
+                      NotFound,
+                      "Schema version not found"))
+                : Completes.withSuccess(
+                    Response.of(
+                      Ok,
+                      Headers.of(of(ContentType, "application/json; charset=UTF-8")),
+                      serialized(schemaVersionData)))
+          );
     }
 
     @Override

--- a/src/test/resources/rest-api-calls.http
+++ b/src/test/resources/rest-api-calls.http
@@ -139,6 +139,11 @@ Accept: application/json
 GET http://localhost:9019/versions/search?organization=Org3&unit=Unit3&context=io.vlingo.schemata5&schema=SchemaDefinedFoo
 Accept: application/json
 
+### Retrieve schema versions by reference
+GET http://localhost:9019/versions/Org3:Unit3:io.vlingo.schemata5:SchemaDefinedFoo:1.0.0
+Accept: application/json
+
+
 ### Search for all schema versions by names
 
 


### PR DESCRIPTION
Adds 
* API endpoint `GET /versions/{reference}` returning schema version data
* API endpoint `GET /versions/{reference}/status` returning schema version state

Required for validation in `vlingo-build-plugins` `PullSchemataMojo`