### PR TITLE
Update URLs for e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,8 +59,8 @@ jobs:
           command: |
             export VLINGO_SCHEMATA_PORT=9019
             java -jar ~/project/target/vlingo-schemata-*-jar-with-dependencies.jar env &
-            export CYPRESS_BASE_URL=http://localhost:9019/app
-            export API_URL=http://localhost:9019
+            export CYPRESS_BASE_URL=http://localhost:9019/
+            export API_URL=http://localhost:9019/api
             cd ~/project/src/test/e2e
             npm run test-multiple
       - store_test_results:

--- a/src/test/e2e/cypress.json
+++ b/src/test/e2e/cypress.json
@@ -1,9 +1,9 @@
 {
-  "baseUrl": "http://localhost:9019/app",
+  "baseUrl": "http://localhost:9019/",
   "numTestsKeptInMemory": 1,
   "chromeWebSecurity": false,
   "video": true,
   "env": {
-    "apiUrl": "http://localhost:9019"
+    "apiUrl": "http://localhost:9019/api"
   }
 }


### PR DESCRIPTION
Related to https://github.com/vlingo/vlingo-schemata/commit/3b28f8f6ffed8f0fc3952f4d2cf224c2ed4f7a0a

```
18:10:58.246 [pool-2-thread-12] WARN  i.v.http.resource.DispatcherActor - No matching resource for method POST and URI /organizations
```


Tests will still fail, but that's because HTML structure has changed since they were written.


