### PR TITLE
Do not run the legacy e2e tests on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,6 @@ jobs:
             - Dockerfile
             - target/
             - src/main/frontend/
-            - src/test/e2e/
       - store_test_results:
           path: target/surefire-reports
       - save_cache:
@@ -34,43 +33,6 @@ jobs:
             - target/node
             - src/main/frontend/node_modules
           key: v2-dependencies-{{ checksum "src/main/frontend/package.json" }}
-  e2e-test:
-    docker:
-      - image: circleci/openjdk:8-jdk-node-browsers
-    steps:
-      - attach_workspace:
-          at: ~/project
-      - restore_cache:
-          keys:
-            - v3-test-dependencies-{{ checksum "src/test/e2e/package.json" }}
-            - v3-test-dependencies-
-      - run:
-          name: Get test dependencies
-          command: |
-            cd ~/project/src/test/e2e
-            npm install
-      - save_cache:
-          paths:
-            - src/test/e2e/node_modules
-            - /home/circleci/.cache/Cypress
-          key: v3-test-dependencies-{{ checksum "src/main/frontend/package.json" }}
-      - run:
-          name: Start server & run E2E tests
-          command: |
-            export VLINGO_SCHEMATA_PORT=9019
-            java -jar ~/project/target/vlingo-schemata-*-jar-with-dependencies.jar env &
-            export CYPRESS_BASE_URL=http://localhost:9019/app
-            export API_URL=http://localhost:9019
-            cd ~/project/src/test/e2e
-            npm run test-multiple
-      - store_test_results:
-          path: src/test/e2e/multiple-results
-      - store_artifacts:
-          path: src/test/e2e/cypress/videos
-          destination: videos
-      - store_artifacts:
-          path: src/test/e2e/cypress/screenshots
-          destination: screenshots
   image:
     docker:
       - image:  circleci/openjdk:8-jdk
@@ -89,12 +51,9 @@ workflows:
   default-workflow:
     jobs:
       - build
-      - e2e-test:
-          requires:
-            - build
       - image:
           requires:
-            - e2e-test
+            - build
           filters:
             branches:
               only:


### PR DESCRIPTION
These tests were implemented for the previous version of the UI and will be removed.