### PR TITLE
Environment runtime type + DB Connection retry

### DIFF
--- a/src/main/java/io/vlingo/schemata/infra/persistence/StateStoreProvider.java
+++ b/src/main/java/io/vlingo/schemata/infra/persistence/StateStoreProvider.java
@@ -7,26 +7,13 @@
 
 package io.vlingo.schemata.infra.persistence;
 
-import java.util.Arrays;
-
 import io.vlingo.actors.ActorInstantiator;
 import io.vlingo.actors.World;
 import io.vlingo.lattice.model.stateful.StatefulTypeRegistry;
 import io.vlingo.lattice.model.stateful.StatefulTypeRegistry.Info;
 import io.vlingo.schemata.NoopDispatcher;
 import io.vlingo.schemata.SchemataConfig;
-import io.vlingo.schemata.query.view.CodeView;
-import io.vlingo.schemata.query.view.ContextView;
-import io.vlingo.schemata.query.view.ContextsView;
-import io.vlingo.schemata.query.view.NamedSchemaView;
-import io.vlingo.schemata.query.view.OrganizationView;
-import io.vlingo.schemata.query.view.OrganizationsView;
-import io.vlingo.schemata.query.view.SchemaVersionView;
-import io.vlingo.schemata.query.view.SchemaVersionsView;
-import io.vlingo.schemata.query.view.SchemaView;
-import io.vlingo.schemata.query.view.SchemasView;
-import io.vlingo.schemata.query.view.UnitView;
-import io.vlingo.schemata.query.view.UnitsView;
+import io.vlingo.schemata.query.view.*;
 import io.vlingo.symbio.State;
 import io.vlingo.symbio.store.DataFormat;
 import io.vlingo.symbio.store.common.jdbc.Configuration;
@@ -40,78 +27,105 @@ import io.vlingo.symbio.store.state.jdbc.JDBCStateStoreActor.JDBCStateStoreInsta
 import io.vlingo.symbio.store.state.jdbc.JDBCStorageDelegate;
 import io.vlingo.symbio.store.state.jdbc.postgres.PostgresStorageDelegate;
 
+import java.util.Arrays;
+
 public class StateStoreProvider {
-    public final StateStore stateStore;
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static StateStoreProvider using(final World world, final SchemataConfig config) throws Exception {
-        final StateStore stateStore;
+  private static final int MAXIMUM_RETRIES = 5;
 
-        if (config.isProductionRuntimeType()) {
-          final Configuration postgresConfiguration =
-                  PostgresConfigurationProvider.configuration(
-                          DataFormat.Text,
-                          config.databaseUrl,
-                          config.databaseName,
-                          config.databaseUsername,
-                          config.databasePassword,
-                          config.databaseOriginator,
-                          true);
+  public final StateStore stateStore;
 
-          final JDBCStorageDelegate<?> delegate = new PostgresStorageDelegate(postgresConfiguration, world.defaultLogger());
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public static StateStoreProvider using(final World world, final SchemataConfig config) throws Exception {
+    final StateStore stateStore =
+            config.isProductionRuntimeType() || config.isEnvironmentRuntimeType() ?
+                    resolveProductionDatabase(world, config) : resolveDeveloperDatabase(world);
 
-          final JDBCEntriesInstantWriter entriesWriter = new JDBCEntriesInstantWriter(typed(delegate), null, null);
+    return new StateStoreProvider(world, stateStore);
+  }
 
-          final ActorInstantiator instantiator = new JDBCStateStoreInstantiator(typed(delegate), entriesWriter, new StateStoreInitializationPrimer(world));
+  private static StateStore resolveProductionDatabase(final World world, final SchemataConfig config) throws Exception {
+    final Configuration databaseConfiguration = buildDatabaseConfiguration(world, config);
 
-          stateStore = world.actorFor(StateStore.class, JDBCStateStoreActor.class, instantiator);
+    final JDBCStorageDelegate<?> delegate =
+            new PostgresStorageDelegate(databaseConfiguration, world.defaultLogger());
 
-        } else {
-          stateStore = world.stage().actorFor(StateStore.class, InMemoryStateStoreActor.class, Arrays.asList(new NoopDispatcher()));
-          new StateStoreInitializationPrimer(world).prime(stateStore);
-        }
+    final JDBCEntriesInstantWriter entriesWriter =
+            new JDBCEntriesInstantWriter(typed(delegate), null, null);
 
-        return new StateStoreProvider(stateStore);
-    }
+    final ActorInstantiator instantiator =
+            new JDBCStateStoreInstantiator(typed(delegate), entriesWriter, new StateStoreInitializationPrimer(world));
 
-    private StateStoreProvider(final StateStore stateStore) {
-        this.stateStore = stateStore;
-    }
+    return world.actorFor(StateStore.class, JDBCStateStoreActor.class, instantiator);
+  }
 
-    @SuppressWarnings({"unchecked"})
-    private static JDBCStorageDelegate<State.TextState> typed(final JDBCStorageDelegate<?> delegate) {
-        return (JDBCStorageDelegate<State.TextState>) delegate;
-    }
+  private static Configuration buildDatabaseConfiguration(final World world, final SchemataConfig config) throws Exception {
+    Exception connectionException = null;
+    for (int retryCount = 1; retryCount <= MAXIMUM_RETRIES; retryCount++) {
+      try {
+        world.defaultLogger().info("[Attempt {}] Connecting to database...", retryCount);
 
-    public static class StateStoreInitializationPrimer implements InitializationPrimer {
-      private final World world;
+        return PostgresConfigurationProvider.configuration(
+                DataFormat.Text,
+                config.databaseUrl,
+                config.databaseName,
+                config.databaseUsername,
+                config.databasePassword,
+                config.databaseOriginator,
+                true);
 
-      StateStoreInitializationPrimer(final World world) {
-        this.world = world;
-      }
-
-      @Override
-      public void prime(final StateStore stateStore) {
-        registerStatefulTypes(stateStore);
-      }
-
-      private void registerStatefulTypes(final StateStore stateStore) {
-        world.defaultLogger().info("=============== PRE-INITIALIZATION ===============");
-        final StatefulTypeRegistry registry = new StatefulTypeRegistry(world);
-
-        registry
-                  .register(new Info<>(stateStore, OrganizationView.class, OrganizationView.class.getSimpleName()))
-                  .register(new Info<>(stateStore, OrganizationsView.class, OrganizationsView.class.getSimpleName()))
-                  .register(new Info<>(stateStore, UnitView.class, UnitView.class.getSimpleName()))
-                  .register(new Info<>(stateStore, UnitsView.class, UnitsView.class.getSimpleName()))
-                  .register(new Info<>(stateStore, ContextView.class, ContextView.class.getSimpleName()))
-                  .register(new Info<>(stateStore, ContextsView.class, ContextsView.class.getSimpleName()))
-                  .register(new Info<>(stateStore, SchemaView.class, SchemaView.class.getSimpleName()))
-                  .register(new Info<>(stateStore, SchemasView.class, SchemasView.class.getSimpleName()))
-                  .register(new Info<>(stateStore, SchemaVersionView.class, SchemaVersionView.class.getSimpleName()))
-                  .register(new Info<>(stateStore, SchemaVersionsView.class, SchemaVersionsView.class.getSimpleName()))
-                  .register(new Info<>(stateStore, NamedSchemaView.class, NamedSchemaView.class.getSimpleName()))
-                  .register(new Info<>(stateStore, CodeView.class, CodeView.class.getSimpleName()));
+      } catch (final Exception exception) {
+        world.defaultLogger().error(exception.getMessage());
+        connectionException = exception;
+        Thread.sleep(5000);
       }
     }
+    throw connectionException;
+  }
+
+  private static StateStore resolveDeveloperDatabase(final World world) {
+    return world.stage().actorFor(StateStore.class, InMemoryStateStoreActor.class, Arrays.asList(new NoopDispatcher()));
+  }
+
+  private StateStoreProvider(final World world, final StateStore stateStore) {
+    this.stateStore = stateStore;
+    new StateStoreInitializationPrimer(world).prime(stateStore);
+  }
+
+  @SuppressWarnings({"unchecked"})
+  private static JDBCStorageDelegate<State.TextState> typed(final JDBCStorageDelegate<?> delegate) {
+    return (JDBCStorageDelegate<State.TextState>) delegate;
+  }
+
+  public static class StateStoreInitializationPrimer implements InitializationPrimer {
+    private final World world;
+
+    StateStoreInitializationPrimer(final World world) {
+      this.world = world;
+    }
+
+    @Override
+    public void prime(final StateStore stateStore) {
+      registerStatefulTypes(stateStore);
+    }
+
+    private void registerStatefulTypes(final StateStore stateStore) {
+      world.defaultLogger().info("=============== PRE-INITIALIZATION ===============");
+      final StatefulTypeRegistry registry = new StatefulTypeRegistry(world);
+
+      registry
+              .register(new Info<>(stateStore, OrganizationView.class, OrganizationView.class.getSimpleName()))
+              .register(new Info<>(stateStore, OrganizationsView.class, OrganizationsView.class.getSimpleName()))
+              .register(new Info<>(stateStore, UnitView.class, UnitView.class.getSimpleName()))
+              .register(new Info<>(stateStore, UnitsView.class, UnitsView.class.getSimpleName()))
+              .register(new Info<>(stateStore, ContextView.class, ContextView.class.getSimpleName()))
+              .register(new Info<>(stateStore, ContextsView.class, ContextsView.class.getSimpleName()))
+              .register(new Info<>(stateStore, SchemaView.class, SchemaView.class.getSimpleName()))
+              .register(new Info<>(stateStore, SchemasView.class, SchemasView.class.getSimpleName()))
+              .register(new Info<>(stateStore, SchemaVersionView.class, SchemaVersionView.class.getSimpleName()))
+              .register(new Info<>(stateStore, SchemaVersionsView.class, SchemaVersionsView.class.getSimpleName()))
+              .register(new Info<>(stateStore, NamedSchemaView.class, NamedSchemaView.class.getSimpleName()))
+              .register(new Info<>(stateStore, CodeView.class, CodeView.class.getSimpleName()));
+    }
+  }
 }


### PR DESCRIPTION
@VaughnVernon 
This PR fixes the runtime type handling in the `StateStore` creation. Additionally, I've implemented the DB connection retry so when Schemata is running on Docker along with a production database, it won't be subject to the container's initialization order.

Thanks.